### PR TITLE
Corrige o erro 403 Forbidden no workflow de release do GitHub Actions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION
O erro ocorria porque o GITHUB_TOKEN padrão não tinha permissão para criar releases. Esta correção adiciona a chave `permissions: contents: write` ao job de release, concedendo explicitamente a permissão necessária para que a Action possa publicar as releases com sucesso.