### PR TITLE
Corrige o workflow de release para garantir a criação de um instalado…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     permissions:
       contents: write
 


### PR DESCRIPTION
…r para Windows (.exe) e resolver problemas de permissão e execução.

- Altera o ambiente de execução do job para `windows-latest`.
- Confirma que a permissão `contents: write` está definida para permitir a criação de releases no GitHub.

Esta alteração substitui as tentativas anteriores e deve prover um fluxo de release estável e que gera o artefato correto para o usuário final.