### PR TITLE
Aprimora o workflow de release para gerar notas automaticamente e man…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Build and release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build application
         run: npm run dist
+
+      - name: Create Draft Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release/*
+          draft: true
+          generate_release_notes: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder --publish always"
+    "dist": "electron-builder"
   },
   "author": "Geovanni Fernandes Garcia",
   "license": "MIT",


### PR DESCRIPTION
…ter a release como draft.

- O script `dist` no `package.json` foi simplificado para apenas construir a aplicação.
- O workflow `.github/workflows/release.yml` foi atualizado para usar a action `softprops/action-gh-release`.
- A nova configuração garante que, a cada push na `main`, uma nova release seja criada como draft, com notas geradas automaticamente a partir dos commits, e com os artefatos de build anexados.