### PR TITLE
Corrige o erro `GH_TOKEN` no workflow de release de forma definitiva.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dist": "electron-builder"
+    "dist": "electron-builder --publish never"
   },
   "author": "Geovanni Fernandes Garcia",
   "license": "MIT",


### PR DESCRIPTION
Altera o script `dist` para `electron-builder --publish never`. Isso força o electron-builder a apenas construir os artefatos, sem tentar publicá-los, o que estava causando um erro de token não encontrado.

A responsabilidade de publicar a release é deixada exclusivamente para a action `softprops/action-gh-release`, que já está configurada corretamente no workflow. Isso cria uma separação de responsabilidades clara e resolve o conflito.