### PR TITLE
Corrige o erro de runtime `Cannot find module 'electron-updater'`.

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
     </div>
 
     <footer>
-        <p style='text-align: center; opacity: 0.7;'>Versão 1.0.1</p>
+        <p style='text-align: center; opacity: 0.7;'>Versão 1.0.2</p>
         <p>Gerador de Layouts de Antenas BINGO - Ferramenta para design e simulação no projeto de rádio astronomia BINGO.</p>
 <div class="footer-links">
     <a href="https://github.com/Geovannisz/LayoutGeneratorBINGO/tree/main" target="_blank" title="Documentação do Projeto (README)">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bingo-layout-generator",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Aplicação Desktop para o Gerador de Layouts BINGO",
   "main": "main.js",
   "scripts": {
@@ -9,10 +9,12 @@
   },
   "author": "Geovanni Fernandes Garcia",
   "license": "MIT",
+  "dependencies": {
+    "electron-updater": "^6.1.1"
+  },
   "devDependencies": {
     "electron": "^25.0.0",
-    "electron-builder": "^24.0.0",
-    "electron-updater": "^6.1.1"
+    "electron-builder": "^24.0.0"
   },
   "build": {
     "appId": "com.example.bingolayoutgenerator",


### PR DESCRIPTION
- O pacote `electron-updater` foi movido de `devDependencies` para `dependencies` no `package.json`. Isso garante que o módulo seja incluído no pacote final da aplicação, resolvendo o erro de tempo de execução.
- A versão foi incrementada para `1.0.2` para lançar esta correção.
- O número da versão no `index.html` foi atualizado para consistência.