### PR TITLE
Corrige o erro de runtime `ENOENT, preload.js not found` e reseta a v…

### DIFF
--- a/index.html
+++ b/index.html
@@ -262,7 +262,7 @@
     </div>
 
     <footer>
-        <p style='text-align: center; opacity: 0.7;'>Versão 1.0.2</p>
+        <p style='text-align: center; opacity: 0.7;'>Versão 1.0.0</p>
         <p>Gerador de Layouts de Antenas BINGO - Ferramenta para design e simulação no projeto de rádio astronomia BINGO.</p>
 <div class="footer-links">
     <a href="https://github.com/Geovannisz/LayoutGeneratorBINGO/tree/main" target="_blank" title="Documentação do Projeto (README)">

--- a/main.js
+++ b/main.js
@@ -40,11 +40,5 @@ app.on('window-all-closed', function () {
   if (process.platform !== 'darwin') app.quit();
 });
 
-// Cria um arquivo de preload vazio para conformidade com as boas práticas de segurança do Electron.
-const fs = require('fs');
-if (!fs.existsSync(path.join(__dirname, 'preload.js'))) {
-    fs.writeFileSync(path.join(__dirname, 'preload.js'), '// Este arquivo é necessário para o Context Isolation do Electron.', 'utf-8');
-}
-
 // Remove o menu padrão para um visual mais limpo
 Menu.setApplicationMenu(null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bingo-layout-generator",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "description": "Aplicação Desktop para o Gerador de Layouts BINGO",
   "main": "main.js",
   "scripts": {

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,3 @@
+// Este arquivo é intencionalmente deixado quase vazio.
+// É usado pelo Electron para pré-carregar scripts em um contexto de renderer isolado por razões de segurança.
+// Boas práticas de segurança do Electron recomendam ter este arquivo, mesmo que vazio.


### PR DESCRIPTION
…ersão para 1.0.0 para um primeiro lançamento estável.

- Cria o arquivo `preload.js` estaticamente para que seja incluído no build.
- Remove o código defensivo em `main.js` que tentava criar `preload.js` em tempo de execução, o que causava o erro em pacotes `asar` somente leitura.
- Reseta a versão em `package.json` e `index.html` para `1.0.0`.